### PR TITLE
API renders articles sorted by category

### DIFF
--- a/app/controllers/v1/categories_controller.rb
+++ b/app/controllers/v1/categories_controller.rb
@@ -1,0 +1,8 @@
+class V1::CategoriesController < ApplicationController
+  before_action :authenticate_user!,  except: :index
+
+  def index
+    categories = Category.all
+    render json: categories, each_serializer: Categories::IndexSerializer
+  end
+end

--- a/app/serializers/categories/index_serializer.rb
+++ b/app/serializers/categories/index_serializer.rb
@@ -1,0 +1,3 @@
+class Categories::IndexSerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   namespace :v1, defaults: { format: :json } do 
     resources :articles, only: [:index, :create, :show, :update]
     resources :payments, only: [:create]
+    resources :categories
   end
   mount_devise_token_auth_for 'User', at: 'auth', skip: [:omniauth_callbacks]
 end

--- a/spec/requests/v1/api_renders_articles_by_category_spec.rb
+++ b/spec/requests/v1/api_renders_articles_by_category_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe 'GET catgeories index', type: :request do 
+  let(:headers) {{HTTP_ACCEPT: 'application/json'}}
+  describe 'lists all categoris' do 
+    #let!(:categories)
+    before do
+      categories = [
+        'Sports',
+        'Politics',
+        'Tech',
+        'Economics',
+        'Lifestyle',
+        'Leisure'
+      ]
+
+      categories.each do |name|
+        create(:category, name: name)
+      end
+      
+    end
+
+    it 'returns 6 categories' do
+      get '/v1/categories', headers: headers
+      binding.pry
+      expect(response_json.length).to eq 6
+    end
+
+    it 'returns status of 200' do
+      get '/v1/categories', headers: headers
+      expect(response.status).to eq 200
+    end
+  end
+end

--- a/spec/requests/v1/api_renders_articles_by_category_spec.rb
+++ b/spec/requests/v1/api_renders_articles_by_category_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe 'GET catgeories index', type: :request do 
   let(:headers) {{HTTP_ACCEPT: 'application/json'}}
   describe 'lists all categoris' do 
-    #let!(:categories)
     before do
       categories = [
         'Sports',
@@ -20,7 +19,6 @@ RSpec.describe 'GET catgeories index', type: :request do
 
     it 'returns 6 categories' do
       get '/v1/categories', headers: headers
-      binding.pry
       expect(response_json.length).to eq 6
     end
 


### PR DESCRIPTION
API renders articles sorted by category
=============================
[PT-link](https://www.pivotaltracker.com/story/show/169653077)

## PR content
In this PR we are adding a feature where the API can render a list of all categories, their names and id's.

## This PR contains:
- categories controller & serializer
- unit test